### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Potential fix for [https://github.com/FrankBurmo/evo/security/code-scanning/2](https://github.com/FrankBurmo/evo/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block for jobs that currently rely on default `GITHUB_TOKEN` permissions, granting only the scopes they actually need. For this workflow, `test` and `build` only need to read repository contents and use standard Actions features; they do not push commits, manage issues, or write to other GitHub resources. The `deploy` job already has minimal required permissions for GitHub Pages, so no change is needed there.

The best way to fix this without changing functionality is:
- Add a root-level `permissions` block (just under `name:` or `on:`) that sets `contents: read`. This applies to all jobs that do not define their own permissions.
- Keep the existing `permissions` block on the `deploy` job so it continues to have the additional `pages: write` and `id-token: write` scopes necessary for `actions/deploy-pages@v4`. Root-level permissions act as defaults and are overridden/extended by job-level permissions, so this is safe.
- No imports, methods, or other code changes are needed; only the YAML workflow file is edited.

Concretely, in `.github/workflows/frontend.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file, so that `test` and `build` run with read-only contents permissions while `deploy` continues to use its explicit job-level settings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
