### PR TITLE
Potential fix for code scanning alert no. 6: Unvalidated dynamic method call

### DIFF
--- a/server/routes/issues.ts
+++ b/server/routes/issues.ts
@@ -142,7 +142,7 @@ router.post(
     const { actionId } = req.params as { actionId: string };
 
     const templateFn = PRODUCT_DEV_TEMPLATES[actionId];
-    if (!templateFn) {
+    if (!templateFn || typeof templateFn !== 'function') {
       return res.status(400).json({
         error: 'Validation Error',
         message: `Ukjent product-dev action: ${actionId}`,
@@ -177,7 +177,7 @@ router.post(
     const { actionId } = req.params as { actionId: string };
 
     const templateFn = ENGINEERING_VELOCITY_TEMPLATES[actionId];
-    if (!templateFn) {
+    if (!templateFn || typeof templateFn !== 'function') {
       return res.status(400).json({
         error: 'Validation Error',
         message: `Ukjent engineering-velocity action: ${actionId}`,


### PR DESCRIPTION
Potential fix for [https://github.com/FrankBurmo/evo/security/code-scanning/6](https://github.com/FrankBurmo/evo/security/code-scanning/6)

To fix this, we should validate that the dynamically looked-up value is indeed a function before calling it. This means tightening the guard around `ENGINEERING_VELOCITY_TEMPLATES[actionId]` so that we only proceed when `templateFn` is both present (truthy) and of type `'function'`. If not, we should respond with a 400 error similar to the existing unknown-action handling, avoiding any unhandled `TypeError`.

Concretely, in `server/routes/issues.ts`:
- In the `/engineering-velocity/:actionId` route, change the `if (!templateFn)` check to `if (!templateFn || typeof templateFn !== 'function')`, and adjust the error message text if desired to keep semantics the same. This ensures that:
  - If `actionId` is unknown (property is `undefined`), we return a 400.
  - If some non-function value is accidentally stored under a valid key, we also return a 400 instead of attempting to call it.
- No new imports or helper functions are required; we only add a `typeof` check inline.

The `/product-dev/:actionId` route has similar structure and could be hardened in the same way for consistency, but CodeQL flagged the engineering-velocity call specifically. Given the instructions, we will update both routes to avoid leaving a similar pattern unfixed and to maintain consistent behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
