### PR TITLE
Potential fix for code scanning alert no. 4: Use of externally-controlled format string

### DIFF
--- a/server/services/issue-service.ts
+++ b/server/services/issue-service.ts
@@ -47,7 +47,7 @@ export async function createTemplateIssue({
     });
     issue = data;
   } catch (error: unknown) {
-    console.error(`Error creating ${logPrefix} issue:`, error);
+    console.error('Error creating %s issue:', logPrefix, error);
     throw {
       status: 500,
       error: 'Failed to create issue',


### PR DESCRIPTION
Potential fix for [https://github.com/FrankBurmo/evo/security/code-scanning/4](https://github.com/FrankBurmo/evo/security/code-scanning/4)

General fix: Never let untrusted data influence the *format string* argument to `console.error` / `console.log` (or `util.format`). Instead, use a constant / trusted format string and pass untrusted values as later arguments, or sanitize/escape `%` from untrusted values before interpolation.

Best fix here: Change the `console.error` call in `createTemplateIssue` so that the first argument is a constant string with a `%s` placeholder for `logPrefix`, and pass `logPrefix` and `error` as subsequent arguments. This preserves all functionality and log content while ensuring that `actionId` cannot introduce format specifiers.

Concretely, in `server/services/issue-service.ts`:

- Replace:

```ts
console.error(`Error creating ${logPrefix} issue:`, error);
```

- With a safe call that uses `logPrefix` as a value, not as part of the format string:

```ts
console.error('Error creating %s issue:', logPrefix, error);
```

This way, even if `logPrefix` (and thus `actionId`) contains `%` characters, they are no longer part of the format string; they are formatted as a plain string argument.

No changes are needed in `server/routes/issues.ts` for this specific vulnerability; `actionId` is still used in HTTP error messages, but those are plain strings returned to the client, not format strings for a variadic formatter.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
