### PR TITLE
Potential fix for code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -48,7 +48,7 @@ export const errorHandler: ErrorRequestHandler = (err: AppError, req, res, _next
   const statusCode = err.status || err.statusCode || 500;
   const message = err.message || 'En intern serverfeil oppstod';
 
-  console.error(`[ERROR] ${req.method} ${req.path}:`, err);
+  console.error('[ERROR] %s %s:', req.method, req.path, err);
 
   res.status(statusCode).json({
     error: statusCode >= 500 ? 'Internal Server Error' : err.error || 'Request Error',


### PR DESCRIPTION
Potential fix for [https://github.com/FrankBurmo/evo/security/code-scanning/3](https://github.com/FrankBurmo/evo/security/code-scanning/3)

In general, to fix this class of issue you must avoid letting untrusted data become part of the *format string* argument to formatted logging functions. Instead, use a constant format string (e.g. `%s %s`) and pass untrusted values as subsequent arguments, or avoid formatting semantics entirely by passing them as separate arguments without interpolation.

In this file, the safest change without altering functionality is to stop constructing the first `console.error` argument via a template literal that includes `req.path`. Instead, pass a constant string as the first argument, and pass `req.method` and `req.path` as separate arguments (either with `%s` placeholders or as separate values). For example:
```ts
console.error('[ERROR] %s %s:', req.method, req.path, err);
```
This keeps the log message structure the same while ensuring any `%` characters in `req.path` are treated as data, not as format specifiers. No new imports or helper functions are required. The change is localized to `server/middleware.ts`, line 51.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
